### PR TITLE
Download URL for zc.buildout 2 bootstrap has changed.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -104,7 +104,7 @@ You can increase verbosity up to ``-vvvv``.
 
 If you want to use an arbitrary ``bootstrap.py`` file, for example to enable support for ``zc.buildout`` 2.x, set the following environment variable:
 
-    $ heroku config:add BOOTSTRAP_PY_URL=http://downloads.buildout.org/2/bootstrap.py
+    $ heroku config:add BOOTSTRAP_PY_URL=https://bootstrap.pypa.io/bootstrap-buildout.py
 
 ### Creating a demo for your Plone package
 

--- a/bin/release
+++ b/bin/release
@@ -4,7 +4,7 @@
 cat << EOF
 ---
 addons:
-  - heroku-postgresql:dev
+  - heroku-postgresql:hobby-dev
 default_process_types:
   web: python configure_zopeconf.py; bin/instance console
 EOF


### PR DESCRIPTION
BTW: I still get an error when running "git push heroku master":

```
remote:        Clean up Installer files
remote: -----> Read BUILDOUT_CFG from env vars, or use default
remote:        Using default: heroku.cfg
remote: -----> Read BUILDOUT_VERBOSITY from env vars, or use default
remote:        Use default buildout verbosity
remote: -----> Read BOOTSTRAP_PY_URL from env vars, or use default
remote:        Use custom bootstrap.py: http://bootstrap.pypa.io/bootstrap-buildout.py
remote: -----> Bootstrap buildout
remote:   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
remote:                                  Dload  Upload   Total   Spent    Left  Speed
remote:   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: L
remote:   0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
remote: python: can't open file 'bootstrap.py': [Errno 2] No such file or directory
remote: 
remote:  !     Push rejected, failed to compile Plone app
remote: 
remote: Verifying deploy...
remote: 
remote: !   Push rejected to radiant-fjord-99541.
remote: 
```

I ran this command before:

> heroku config:add BOOTSTRAP_PY_URL=http://bootstrap.pypa.io/bootstrap-buildout.py
