### PR TITLE
Update the download link for bootstrap.py file.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 0.2 (2014-11-01)
 ----------------
 
+- Update the download link for the bootstrap.py file.
 - [MIGRATION REQUIRED] Move the package to the Plone Foundation organization
   on GitHub. These requires updates to:
   * URLs in heroku-button-plone apps

--- a/Readme.md
+++ b/Readme.md
@@ -104,7 +104,7 @@ You can increase verbosity up to ``-vvvv``.
 
 If you want to use an arbitrary ``bootstrap.py`` file, for example to enable support for ``zc.buildout`` 2.x, set the following environment variable:
 
-    $ heroku config:add BOOTSTRAP_PY_URL=http://downloads.buildout.org/2/bootstrap.py
+    $ heroku config:add BOOTSTRAP_PY_URL=https://bootstrap.pypa.io/bootstrap-buildout.py
 
 ### Creating a demo for your Plone package
 

--- a/bin/compile
+++ b/bin/compile
@@ -68,7 +68,7 @@ if [ -f $ENV_DIR/BOOTSTRAP_PY_URL ]; then
     export "BOOTSTRAP_PY_URL=$(cat $ENV_DIR/BOOTSTRAP_PY_URL)"
     echo "Use custom bootstrap.py: ${BOOTSTRAP_PY_URL}" | indent
 else
-    export "BOOTSTRAP_PY_URL=http://downloads.buildout.org/2/bootstrap.py"
+    export "BOOTSTRAP_PY_URL=https://bootstrap.pypa.io/bootstrap-buildout.py"
     echo "Use default bootstrap.py: ${BOOTSTRAP_PY_URL}" | indent
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -75,7 +75,7 @@ fi
 cd $BUILD_DIR
 echo "-----> Bootstrap buildout"
 wget -O bootstrap.py "${BOOTSTRAP_PY_URL}"
-python bootstrap.py -c $BUILDOUT_CFG --setuptools-version 26.1.1
+python bootstrap.py -c $BUILDOUT_CFG --setuptools-version 26.1.1 --buildout-version 1.7.1
 echo "-----> Run bin/buildout -c ${BUILDOUT_CFG} ${BUILDOUT_VERBOSITY}"
 bin/buildout -c $BUILDOUT_CFG $BUILDOUT_VERBOSITY
 

--- a/bin/compile
+++ b/bin/compile
@@ -74,7 +74,7 @@ fi
 
 cd $BUILD_DIR
 echo "-----> Bootstrap buildout"
-curl -o bootstrap.py L "${BOOTSTRAP_PY_URL}"
+wget -O bootstrap.py "${BOOTSTRAP_PY_URL}"
 python bootstrap.py -c $BUILDOUT_CFG
 echo "-----> Run bin/buildout -c ${BUILDOUT_CFG} ${BUILDOUT_VERBOSITY}"
 bin/buildout -c $BUILDOUT_CFG $BUILDOUT_VERBOSITY

--- a/bin/compile
+++ b/bin/compile
@@ -75,7 +75,7 @@ fi
 cd $BUILD_DIR
 echo "-----> Bootstrap buildout"
 wget -O bootstrap.py "${BOOTSTRAP_PY_URL}"
-python bootstrap.py -c $BUILDOUT_CFG
+python bootstrap.py -c $BUILDOUT_CFG --setuptools-version 26.1.1
 echo "-----> Run bin/buildout -c ${BUILDOUT_CFG} ${BUILDOUT_VERBOSITY}"
 bin/buildout -c $BUILDOUT_CFG $BUILDOUT_VERBOSITY
 


### PR DESCRIPTION
The deploy script was broken due to the fact that the download link for bootstrap.py was changed to https://bootstrap.pypa.io/bootstrap-buildout.py from http://downloads.buildout.org/2/bootstrap.py